### PR TITLE
Fixed problem with navigation stack back navigation

### DIFF
--- a/src/uikit/NavigatorHeader/NavigatorHeaderContainer.js
+++ b/src/uikit/NavigatorHeader/NavigatorHeaderContainer.js
@@ -26,7 +26,7 @@ class NavigatorHeaderContainer extends Component {
   // ///////////////////////////////////////////////////////////////////////////////
 
   goBack () {
-    this.props.settings.navigation.goBack()
+    this.props.settings.navigation.pop()
   }
 
   toggleDrawer () {


### PR DESCRIPTION
This fixes the following problem in iOS devices:
the back button click handler is not working, when you click it the navigator stack doesn't go back to the previous item in the stack.
Fixed by using .pop() instead of .goBack()